### PR TITLE
Update opencv dependency for but_velodyne_proc

### DIFF
--- a/segway_sensor_filters/but_velodyne/but_velodyne_proc/CMakeLists.txt
+++ b/segway_sensor_filters/but_velodyne/but_velodyne_proc/CMakeLists.txt
@@ -23,7 +23,7 @@ include_directories( ${EIGEN_INCLUDE_DIRS})
 find_package( OpenCV REQUIRED )
 include_directories( ${OpenCV_INCLUDE_DIRS})
 
-catkin_package(CATKIN_DEPENDS eigen opencv nav_msgs sensor_msgs)
+catkin_package(CATKIN_DEPENDS eigen nav_msgs sensor_msgs)
 include_directories(include ${catkin_INCLUDE_DIRS})
 
 add_library( butvelo 

--- a/segway_sensor_filters/but_velodyne/but_velodyne_proc/package.xml
+++ b/segway_sensor_filters/but_velodyne/but_velodyne_proc/package.xml
@@ -26,7 +26,7 @@
   <build_depend>velodyne_pointcloud</build_depend>
   <build_depend>costmap_2d</build_depend>
   <build_depend>eigen</build_depend>
-  <build_depend>opencv</build_depend>
+  <build_depend>cv_bridge</build_depend>
   <build_depend>roslint</build_depend>
 
   <run_depend>nodelet</run_depend>
@@ -38,7 +38,7 @@
   <run_depend>velodyne_pointcloud</run_depend>
   <run_depend>costmap_2d</run_depend>
   <run_depend>eigen</run_depend>
-  <run_depend>opencv</run_depend>
+  <run_depend>cv_bridge</run_depend>
   
   <export>
     <nodelet plugin="${prefix}/nodelets.xml" />


### PR DESCRIPTION
OpenCV became a system dependency in indigo, and the backwards compatible way of depending on it is to depend instead on cv_bridge which will pull it in. See http://wiki.ros.org/indigo/Migration#OpenCV