### PR TITLE
Fix dependence on segway_sensor_filters

### DIFF
--- a/segway_bringup/package.xml
+++ b/segway_bringup/package.xml
@@ -16,7 +16,9 @@
     <run_depend>robot_localization</run_depend>
     <run_depend>yocs_cmd_vel_mux</run_depend>
     <run_depend>urg_node</run_depend>
-    <run_depend>ublox</run_depend>
+    <run_depend>ublox_gps</run_depend>
+    <run_depend>ublox_msgs</run_depend>
+    <run_depend>ublox_serialization</run_depend>
     <run_depend>segway_ros</run_depend>
     <run_depend>segway_upstart</run_depend>
     <run_depend>but_velodyne</run_depend>

--- a/segway_bringup/package.xml
+++ b/segway_bringup/package.xml
@@ -21,7 +21,7 @@
     <run_depend>ublox_serialization</run_depend>
     <run_depend>segway_ros</run_depend>
     <run_depend>segway_upstart</run_depend>
-    <run_depend>but_velodyne</run_depend>
+    <run_depend>but_velodyne_proc</run_depend>
     <run_depend>ira_laser_tools</run_depend>
     <run_depend>range_sensor_filters</run_depend>
     <run_depend>si_utils</run_depend>

--- a/segway_bringup/package.xml
+++ b/segway_bringup/package.xml
@@ -19,7 +19,9 @@
     <run_depend>ublox</run_depend>
     <run_depend>segway_ros</run_depend>
     <run_depend>segway_upstart</run_depend>
-    <run_depend>segway_sensor_filters</run_depend>
+    <run_depend>but_velodyne</run_depend>
+    <run_depend>ira_laser_tools</run_depend>
+    <run_depend>range_sensor_filters</run_depend>
     <run_depend>si_utils</run_depend>
     <run_depend>segway_v3_config</run_depend>
 


### PR DESCRIPTION
The segway_bringup package was depending on segway_sensor_filters, which is a metapackage. Depending on a metapackage isn't allowed, so instead it now depends on each of the specific sensor filter packages.

See https://github.com/catkin/catkin_tools/issues/370#issuecomment-219157118 for an explanation of why packages aren't supposed to depend on metapackages.